### PR TITLE
Finished parameter requirements from sprint 2: clear and replace

### DIFF
--- a/src/umlclass.py
+++ b/src/umlclass.py
@@ -218,6 +218,18 @@ class UmlClass:
         return 0
     
     def add_parameter(self, methodname:str, arity:int, parameter:str):
+        """Add a parameter to a specific method overload.
+
+        Params:
+            methodname: name of the method to add to
+            arity: the method overload to add to
+            parmaeter: the name of the new parameter being added
+        Returns:
+
+        Exceptions:
+            MethodOverloadNotExistsException
+            DuplicateMethodOverloadException
+        """
         if not self._overload_exists(methodname, arity):
             raise errors.MethodOverloadNotExistsException()
         
@@ -231,6 +243,19 @@ class UmlClass:
         self.class_methods.get(methodname)[len(uml_method.params)] = uml_method
         
     def rename_parameter(self, methodname:str, arity:int, oldname:str, newname:str):
+        """Rename a parameter on a specific method overload.
+
+        Params:
+            methodname: name of the method
+            arity: the method overload
+            oldname: the name of the parameter to rename
+            newname: the new name for the parameter
+        Returns:
+
+        Exceptions:
+            MethodOverloadNotExistsException
+            DuplicateMethodOverloadException
+        """
         if not self._overload_exists(methodname, arity):
             raise errors.MethodOverloadNotExistsException()
         
@@ -238,6 +263,18 @@ class UmlClass:
         uml_method.rename_parameter(oldname, newname)
 
     def remove_parameter(self, methodname:str, arity:int, parameter:str):
+        """Remove a parameter from a specific method overload.
+
+        Params:
+            methodname: name of the method
+            arity: the method overload
+            oldname: the name of the parameter to remove
+        Returns:
+
+        Exceptions:
+            MethodOverloadNotExistsException
+            DuplicateMethodOverloadException
+        """
         if not self._overload_exists(methodname, arity):
             raise errors.MethodOverloadNotExistsException()
         
@@ -249,6 +286,56 @@ class UmlClass:
 
         self.class_methods.get(methodname).pop(arity)
         self.class_methods.get(methodname)[len(uml_method.params)] = uml_method
+
+    def remove_all_parameters(self, methodname:str, arity:int):
+        """Remove all parameters from a specific method overload.
+
+        Params:
+            methodname: name of the method
+            arity: the method overload
+        Returns:
+
+        Exceptions:
+            MethodOverloadNotExistsException
+            DuplicateMethodOverloadException
+        """
+        if not self._overload_exists(methodname, arity):
+            raise errors.MethodOverloadNotExistsException()
+
+        if self._overload_exists(methodname, 0):
+            raise errors.DuplicateMethodOverloadException()
+
+        uml_method = self.class_methods.get(methodname).get(arity)
+        uml_method.clear_parameters()
+
+        self.class_methods.get(methodname).pop(arity)
+        self.class_methods.get(methodname)[len(uml_method.params)] = uml_method
+
+    def replace_all_parameters(self, methodname:str, arity:int, parameters:list[str]):
+        """Replace all parameters from a specific method overload with new parameters.
+
+        Params:
+            methodname: name of the method
+            arity: the method overload
+            parameters: list of new parameter names
+        Returns:
+
+        Exceptions:
+            MethodOverloadNotExistsException
+            DuplicateMethodOverloadException
+        """
+        if not self._overload_exists(methodname, arity):
+            raise errors.MethodOverloadNotExistsException()
+
+        if self._overload_exists(methodname, len(parameters)):
+            raise errors.DuplicateMethodOverloadException()
+        
+        uml_method = self.class_methods.get(methodname).get(arity)
+        uml_method.replace_parameters(parameters)
+
+        self.class_methods.get(methodname).pop(arity)
+        self.class_methods.get(methodname)[len(uml_method.params)] = uml_method
+
 
     def to_dict(self) -> dict:
         methods = []

--- a/src/umlcontroller.py
+++ b/src/umlcontroller.py
@@ -107,6 +107,7 @@ class UmlCommands:
             id = r"parameter rename"
             regex = r"^parameter rename ([A-Za-z][A-Za-z0-9_]*) ([A-Za-z][A-Za-z0-9_]*)$"
             usage = "parameter rename <name> <new name>"
+            # usage = "parameter replace <name> <new name> <new type>"
         
         class DeleteParameter(UmlCommand):
             id = r"parameter delete"
@@ -118,12 +119,22 @@ class UmlCommands:
             regex = r"^parameter list$"
             usage = "parameter list"
         
+        class ClearParameter(UmlCommand):
+            id = r"parameter clear all"
+            regex = r"^parameter clear all$"
+            usage = "parameter clear all"
+        
+        class ReplaceParameter(UmlCommand):
+            id = r"parameter replace all"
+            regex = r"^parameter replace all(\s[A-Za-z][A-Za-z0-9_]*)+$"
+            usage = "parameter replace all <param list>"
+        
         class HelpParameter(UmlCommand):
             id = r"parameter"
             regex = r"^parameter (help){0,1}$"
             usage = "parameter commands:\n"
         
-        Commands:list[UmlCommand] = [AddParameter, RenameParameter, DeleteParameter, ListParameter, HelpParameter]
+        Commands:list[UmlCommand] = [AddParameter, RenameParameter, DeleteParameter, ListParameter, ClearParameter, ReplaceParameter, HelpParameter]
         Usage:str = HelpParameter.usage + "\n".join([c.usage for c in Commands[:-1]])
 
 class UmlController:
@@ -707,6 +718,13 @@ class UmlController:
                 if m.name == active_method and len(m.params) == arity:
                     self.view.render_umlmethod(m)
                     break
+        elif umlcommand == UmlCommands.UmlParameterCommands.ClearParameter:
+            self.model.clear_all_parameters(active_class, active_method, arity)
+            self.set_active_method(active_method, 0)
+        elif umlcommand == UmlCommands.UmlParameterCommands.ReplaceParameter:
+            parameters = args[3:]
+            self.model.replace_all_parameters(active_class, active_method, arity, parameters)
+            self.set_active_method(active_method, len(parameters))
         elif umlcommand == UmlCommands.UmlParameterCommands.HelpParameter:
             self.view.handle_exceptions(UmlCommands.UmlParameterCommands.Usage)
 

--- a/src/umlmethod.py
+++ b/src/umlmethod.py
@@ -113,6 +113,21 @@ class UmlMethod:
         """
         self.params.clear()
 
+    def replace_parameters(self, parameters:list[str]):
+        """Replaces all UmlParameter from the UmlMethod.
+        Params:
+            parameters: a list of parameter names to replace existing parameters with.
+        Returns:
+            0 if the parameter was successfully added  
+            a number corresponding to an error in the errors class
+            if a parameter was not removed form the class
+        Exceptions:
+            
+        """
+
+        self.clear_parameters()
+        self.add_parameters(parameters)
+
     def to_dict(self):
         return {
             'name': self.name,

--- a/src/umlmodel.py
+++ b/src/umlmodel.py
@@ -450,6 +450,39 @@ class UmlProject:
         uml_class.rename_parameter(methodname, arity, oldname, newname)
 
     @_has_changed
+    def clear_all_parameters(self, classname:str, methodname:str, arity:int):
+        """Clears all parameters from a method overload.
+
+        Params:
+            classname: current name of the class
+            methodname: name of the method
+            arity: method overload to operate on
+        Returns:
+            0: if successful
+        Exceptions:
+            None
+        """
+        uml_class = self.get_umlclass(classname)
+        uml_class.remove_all_parameters(methodname, arity)
+    
+    @_has_changed
+    def replace_all_parameters(self, classname:str, methodname:str, arity:int, parameters:list[str]):
+        """Replace all parameters from a method overload with a new parameter list.
+
+        Params:
+            classname: current name of the class
+            methodname: name of the method
+            arity: method overload to operate on
+            parameters: new list of parameter names
+        Returns:
+            0: if successful
+        Exceptions:
+            None
+        """
+        uml_class = self.get_umlclass(classname)
+        uml_class.replace_all_parameters(methodname, arity, parameters)
+
+    @_has_changed
     def delete_parameter(self, classname:str, methodname:str, arity:int, parameter:str):
         uml_class = self.get_umlclass(classname)
         uml_class.remove_parameter(methodname, arity, parameter)

--- a/tests/test_classObj.py
+++ b/tests/test_classObj.py
@@ -415,3 +415,6 @@ def test_remove_method_all_overloads():
     test_class.remove_all_overloads(test_method_name)
 
     assert test_class.class_methods == test_val_methods
+
+# TODO - Unit tests replace all method parameters
+# TODO - Unit tests clear all method parameters


### PR DESCRIPTION
Adds `parameter replace all` and `parameter clear all` commands to the model, controller.

CLI innately handles the new commands, does not include GUI implementation.

Unit tests are labeled as `TODO` and will be written with `type` requirements.